### PR TITLE
Fix or Update Website repository URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
         <div class="row">
           <div class="col-lg-4">
 	    <h4 class="text-center">
-	      <a href="http://github.com/redpen-cc/redpen"><i class="fa fa-github" aria-hidden="true"></i> Edit on GitHub</a>
+	      <a href="https://github.com/redpen-cc/website"><i class="fa fa-github" aria-hidden="true"></i> Edit on GitHub</a>
 	    </h4>
           </div>
 


### PR DESCRIPTION
Initially I would liked to update https://redpen.cc/ around some information.
Then clicked below `Edit on GitHub` link, it jumps to https://github.com/redpen-cc/redpen

<img width="491" alt="スクリーンショット 2021-03-09 2 49 28" src="https://user-images.githubusercontent.com/1180335/110360479-19176700-8082-11eb-88d6-d935edff48d0.png">

I don't know the repository history, but I guess this repository is the website source. 
Is this correct understanding?
