### PR TITLE
Update link to latest release in news

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
 		      <p class="subtitle lang-en" >
 			<a href="http://redpen.cc/docs/latest/index.html#restuucturedtext">Now RedPen supports reStrucutredText format.</p>
 		      <p class="subtitle lang-en" >
-			<a href="https://github.com/redpen-cc/redpen/releases/tag/redpen-1.9.0">RedPen v1.9.0</a> is released.</p>
+			<a href="https://github.com/redpen-cc/redpen/releases/tag/redpen-1.10.4">RedPen v1.10.4</a> is released.</p>
 		      <p class="subtitle lang-en" >
                         <a href="http://blog.redpen.cc/2015/09/08/writing-extension-with-javascript/">Blog post</a> on writing extensions with JavaScript</p>
 		      <p class="subtitle lang-en" >
@@ -261,7 +261,7 @@
 		      <p class="subtitle lang-ja" >
 			<a href="https://gitter.im/redpen-cc/redpen/redpen-ja">日本語サポート用のチャットルーム (Gitter)</a> が作成されました。</p>
 		      <p class="subtitle lang-ja" >
-			<a href="https://github.com/redpen-cc/redpen/releases/tag/redpen-1.9.0">RedPen v1.9.0</a> がリリースされました。</p>
+			<a href="https://github.com/redpen-cc/redpen/releases/tag/redpen-1.10.4">RedPen v1.10.4</a> がリリースされました。</p>
 		      <p class="subtitle lang-ja" >
 			<a href="https://plugins.jetbrains.com/plugin/8210">RedPen IntelliJ IDEA プラグイン</a> がリリースされました。</p>
 		      <p class="subtitle lang-ja" >


### PR DESCRIPTION
https://github.com/redpen-cc/redpen/releases/tag/redpen-1.9.0 looks older.
How about to link latest version?
https://github.com/redpen-cc/redpen/releases/tag/redpen-1.10.4

<img width="748" alt="スクリーンショット 2021-03-09 3 01 44" src="https://user-images.githubusercontent.com/1180335/110361943-030aa600-8084-11eb-876b-92c3fd2d4289.png">
